### PR TITLE
Remove unused import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ import time
 from binaryninja import Settings
 from binaryninja.log import log_debug, log_warn
 from binaryninja.plugin import BackgroundTaskThread, PluginCommand
-from binaryninjaui import UIContextNotification, UIContext, DockHandler
+from binaryninjaui import UIContextNotification, UIContext
 import pypresence
 
 Settings().register_group("discordpresence", "Discord Presence")


### PR DESCRIPTION
also fixes error on 5.0.7220-dev:
[ScriptingProvider] Failed to import python plugin: community/psifertex_discordpresence: cannot import name 'DockHandler' from 'binaryninjaui' (/home/user/.local/share/binaryninja/plugins/../python/binaryninjaui/__init__.py)
